### PR TITLE
Fix for use isinstance({}, dict)

### DIFF
--- a/flask_mako.py
+++ b/flask_mako.py
@@ -205,6 +205,9 @@ def _lookup(app):
 def _render(template, context, app):
     """Renders the template and fires the signal"""
     context.update(app.jinja_env.globals)
+    # Jinja2 has a function name `dict` in DEFAULT_NAMESPACE. This interferes
+    # with the built-in `dict`. Such as isinstance({}, dict)
+    context.pop('dict', None)
     app.update_template_context(context)
     try:
         rv = template.render(**context)


### PR DESCRIPTION
I use flask-mako. But there was a problem, Below is my code:
### app.py

```
from flask import Flask
from flask.ext.mako import MakoTemplates, render_template
from plim import preprocessor

app = Flask(__name__, template_folder="templates")
app.config['MAKO_TRANSLATE_EXCEPTIONS'] = False
app.config['MAKO_DEFAULT_FILTERS'] = ['decode.utf_8', 'h'] 
#app.config['MAKO_PREPROCESSOR'] = preprocessor

mako = MakoTemplates()
mako.init_app(app)

@app.route('/')
def index():
    s = 'a string'
    return render_template('test_no_plim.html', **locals())

if __name__ == '__main__':
    app.run(debug=True)
```
### test_no_plim.html

```
<html>
  <body>
    <div>
      % if isinstance(s, dict):
      <a>dict</a>
      % else:
      <p>not dict</p>
    % endif
    </div>
  </body>
</html>
```

Display the following error when I visit `http://127.0.0.1:5000/`

```
TypeError

TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types
```

I found the reason is in jinja2 's [commit 76c280bf5b2263a435e38e0b3612c23eb633ed79](https://github.com/mitsuhiko/jinja2/commit/76c280bf5b2263a435e38e0b3612c23eb633ed79). It add a function that named `dict` interferes  the built-in `dict` after update context from `app.jinja_env.globals`
