### PR TITLE
Fixed ExtDeprecationWarning caused by Flask extension import

### DIFF
--- a/flask_mako.py
+++ b/flask_mako.py
@@ -11,7 +11,7 @@
 """
 import os, sys
 
-from flask.helpers import locked_cached_property
+from flask.helpers import cached_property
 from flask.signals import template_rendered
 
 # Find the context stack so we can resolve which application is calling this

--- a/flask_mako.py
+++ b/flask_mako.py
@@ -11,7 +11,7 @@
 """
 import os, sys
 
-from flask.helpers import cached_property
+from werkzeug.utils import cached_property
 from flask.signals import template_rendered
 
 # Find the context stack so we can resolve which application is calling this

--- a/flask_mako.py
+++ b/flask_mako.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from flask import _request_ctx_stack as stack
 
-from werkzeug.debug.tbtools import Traceback, Frame, Line
+from werkzeug.debug.tbtools import DebugTraceback as Traceback, DebugFrameSummary as Frame
 
 from mako.lookup import TemplateLookup
 from mako.template import Template

--- a/flask_mako.py
+++ b/flask_mako.py
@@ -32,7 +32,7 @@ from mako.exceptions import RichTraceback, text_error_template
 
 itervalues = getattr(dict, 'itervalues', dict.values)
 
-_BABEL_IMPORTS =  'from flask.ext.babel import gettext as _, ngettext, ' \
+_BABEL_IMPORTS =  'from flask_babel import gettext as _, ngettext, ' \
                   'pgettext, npgettext'
 _FLASK_IMPORTS =  'from flask.helpers import url_for, get_flashed_messages'
 


### PR DESCRIPTION
Fixed ExtDeprecationWarning by updating old-style Flask extension import for Babel

References: http://flask.pocoo.org/docs/0.11/upgrading/#extension-imports
