### PR TITLE
Update doc to include MAKO_DEFAULT_FILTERS option

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ MAKO_FILESYSTEM_CHECKS      filesystem_checks
 MAKO_STRICT_UNDEFINED       strict_undefined
 MAKO_CACHE_IMPL             cache_impl
 MAKO_CACHE_ARGS             cache_args
+MAKO_DEFAULT_FILTERS        default_filters
 =======================     =====================
 
 Registration


### PR DESCRIPTION
The configuration option was introduced by #1 

MAKO_DEFAULT_FILTERS sets default_filters.  Additional documentation on default_filters can be found at https://docs.makotemplates.org/en/latest/filtering.html#the-default-filters-argument