### PR TITLE
[ART-4958] Fork & Update dead project  (flask-mako) to be compatible with Flask-Babel

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Registration
 Applications can be registered directly in the extension constructor::
 
     from flask import Flask
-    from flask.ext.mako import MakoTemplates
+    from flask_mako import MakoTemplates
 
     app = Flask(__name__)
     mako = MakoTemplates(app)
@@ -97,7 +97,7 @@ as Jinja2 templates. Additionally, Mako templates receive the same context as
 Jinja2 templates. This allows you to use the same variables as you normally
 would (``g``, ``session``, ``url_for``, etc)::
 
-    from flask.ext.mako import render_template
+    from flask_mako import render_template
 
     def hello_mako():
         return render_template('hello.html', name='mako')

--- a/flask_mako.py
+++ b/flask_mako.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    flask.ext.mako
+     flask_mako
     ~~~~~~~~~~~~~~~~~~~~~~~
 
     Extension implementing Mako Templates support in Flask with support for
@@ -32,7 +32,7 @@ from mako.exceptions import RichTraceback, text_error_template
 
 itervalues = getattr(dict, 'itervalues', dict.values)
 
-_BABEL_IMPORTS =  'from flask.ext.babel import gettext as _, ngettext, ' \
+_BABEL_IMPORTS =  'from flask_babel import gettext as _, ngettext, ' \
                   'pgettext, npgettext'
 _FLASK_IMPORTS =  'from flask.helpers import url_for, get_flashed_messages'
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Mako',
-    version='0.4',
+    version='0.5',
     url='https://github.com/benselme/flask-mako',
     license='BSD',
     author='Beranger Enselme, Frank Murphy',

--- a/tests/test_mako.py
+++ b/tests/test_mako.py
@@ -10,8 +10,8 @@ from contextlib import contextmanager
 
 import flask
 from flask import Flask, Blueprint, g
-from flask.ext.mako import (MakoTemplates, TemplateError, render_template,
-                            render_template_string, render_template_def)
+from flask_mako import (MakoTemplates, TemplateError, render_template,
+                        render_template_string, render_template_def)
 
 from mako.exceptions import CompileException
 


### PR DESCRIPTION
See: https://github.com/benselme/flask-mako/issues/19

The "flask.ext" style of naming/importing modules has been [deprecated since 2016](https://github.com/pallets/flask/pull/1484). [Here's the reasoning](https://github.com/pallets/flask/issues/1135#issuecomment-61860862). 

If you see a flask.ext import in documentation for a Flask extension, that's a red flag that the code is abandonware. It's been deprecated for 6 years now. The Flask docs no longer mention it, beyond the deprecation warnings in the Changelog


Copying the suggested fork from the end of issue:
https://github.com/benselme/flask-mako/commit/a5ec694b6974d1aa197ff5e773112ed12bcfbfdc

